### PR TITLE
Fixed for Django 2.0

### DIFF
--- a/search_admin_autocomplete/admin.py
+++ b/search_admin_autocomplete/admin.py
@@ -2,7 +2,10 @@ import json
 
 from django.contrib import admin
 from django.conf.urls import url
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse
 from django.http.response import HttpResponse, HttpResponseBadRequest
 
 


### PR DESCRIPTION
The old import for reverse() doesn't work in 2.0.
I added a try-except, with the [new import](https://docs.djangoproject.com/en/2.0/ref/urlresolvers/#reverse). 